### PR TITLE
Add PDF documentation page

### DIFF
--- a/doc/extradocs.rst
+++ b/doc/extradocs.rst
@@ -1,0 +1,117 @@
+Additional IRAF documentation
+=============================
+
+Aside from the online help pages and the documentation distributed
+with the system there is a large collection of user material available
+as PDF documents.
+
+
+Introductionary Materials
+-------------------------
+
+* `A Beginner's Guide to Using IRAF (IRAF Version 2.10)
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/beguide.pdf>`_,
+  Jeannette Barnes, August 1993.
+
+* `A User's Introduction to the IRAF Command Language Version 2.3
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/cluser.pdf>`_,
+  Peter MB Shames and Doug Tody, August 1986.
+
+* `Preliminary Test Procedure for IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/testproc.pdf>`_, IRAF Version
+  2.11, Jeannette Barnes, revised September 1997
+
+* `A Userguide to Fits format in IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/fits_userguide.pdf>`_,
+  Nelson Zarate, August 1997.
+
+  
+Photometry
+----------
+
+* `A User's Guide to CCD Reductions with IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/ccduser3.pdf>`_,
+  Philip Massey, February 1997.
+
+* `Photometry Using IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/photom.pdf>`_, Lisa A. Wells, February 1994.
+
+* `A User's Guide to Stellar CCD Photometry with IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/daophot2.pdf>`_,
+  Philip Massey and Lindsey Davis, April 1992.
+
+* `Specifications for the Aperture Photometry Package
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/apspec.pdf>`_,
+  Lindsey Davis, revised October 1987.
+
+* `A User's Guide to the IRAF Apphot Package
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/apuser.pdf>`_,
+  Lindsey Davis, revised May 1989.
+
+* `A Reference Guide to the IRAF/DAOPHOT Package
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/daorefman.pdf>`_,
+  Lindsey E. Davis, January 1994
+
+
+Spectroscopy
+------------
+
+* `A User's Guide to CCD Reductions with IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/ccduser3.pdf>`_,
+  Philip Massey, February 1997.
+
+* `A User's Guide to Reducing Slit Spectra with IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/spect.pdf>`_,
+  Phil Massey, Frank Valdes, Jeannette Barnes, April 1992
+
+* `A User's Guide to Reducing Echelle Spectra With IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/ech.pdf>`_,
+  Daryl Willmarth and Jeannette Barnes, May 1994
+
+* `Guide to the Multifiber Reduction Task DOFIBERS
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/dofibers.pdf>`_,
+  Francisco Valdes, July 1995
+
+* `Guide to the HYDRA Reduction Task DOHYDRA
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/dohydra.pdf>`_,
+  Francisco Valdes, July 1995
+
+* `Guide to the Slit Spectra Reduction Task DOSLIT
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/doslit.pdf>`_,
+  Francisco Valdes, February 1993
+
+* `Guide to the Slit Spectra Reduction Task DOECSLIT
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/doecslit.pdf>`_,
+  Francisco Valdes, February 1993
+
+
+General Image Processing
+------------------------
+
+* `Rectifying and Registering Images Using IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/reg.pdf>`_,
+  Lisa A. Wells, April 1994
+
+* `Cleaning Images of Bad Pixels and Cosmic Rays Using IRAF
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/clean.pdf>`_,
+  Lisa A. Wells and David J. Bell, September 1994
+
+
+Programming Guides
+------------------
+
+* `A User's Guide to Fortran Programming in IRAF The IMFORT Interface
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/imfort.pdf>`_,
+  Doug Tody, September 1986.
+
+* `Specifying Pixel Directories with IMFORT
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/imfortmem.pdf>`_,
+  Doug Tody, June 1989.
+
+* `An Introductory User's Guide to IRAF Scripts
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/script.pdf>`_,
+  revised by Rob Seaman, September 1989.
+
+* `An Introductory User's Guide to IRAF SPP Programming
+  <https://raw.githubusercontent.com/iraf-community/iraf-docs/main/pdf/sppguide.pdf>`_,
+  Rob Seaman, October 1992.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ IRAF is maintained by the iraf-community_.
    std_gl
    unixsmg
    releases/index
+   extradocs
    PyRAF tutorial <https://pyraf.readthedocs.io/>
 
 .. _iraf-community: https://iraf-community.github.io

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@ IRAF documentation
 
 Welcome to the IRAF documentation! IRAF is the Image Reduction and Analysis
 Facility, a general purpose software system for the reduction and
-analysis of astronomical data. After reaching its enf of life in 2019,
+analysis of astronomical data. After reaching its end of life in 2019,
 IRAF is maintained by the iraf-community_.
 
 .. toctree:: :maxdepth: 1

--- a/tools/irafdocs.py
+++ b/tools/irafdocs.py
@@ -251,7 +251,10 @@ mainhelp = """
 
 def copy_static(target):
     for target_path in target.rglob("*.rst"):
-        if str(target_path.relative_to(target)) != "index.rst":
+        if str(target_path.relative_to(target)) not in (
+            "index.rst",
+            "extradocs.rst",
+        ):
             target_path.unlink()
 
     src = pathlib.Path(os.environ["iraf"]) / "doc"


### PR DESCRIPTION
This adds the missing PDF documentation from the old IRAF home page.
The documentation PDF files are taken from [iraf-community/iraf-docs](https://github.com/iraf-community/iraf-docs), which was cloned from [noirlab-iraf/iraf-docs](https://github.com/noirlab-iraf/iraf-docs).