### PR TITLE
Remove “Edit on Github” buttons

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}


### PR DESCRIPTION
See https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html