### PR TITLE
Allow unstructured help files

### DIFF
--- a/doc/tasks/language/cl.rst
+++ b/doc/tasks/language/cl.rst
@@ -7,10 +7,6 @@ cl: Execute commands from the standard input
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  cl    -- call the CL as a task
-  clbye -- like cl(), but closes current script file too
-  </pre></div>
   <section id="s_parameters">
   <h3>Parameters</h3>
   <dl id="l_gcur">

--- a/doc/tasks/language/clbye.rst
+++ b/doc/tasks/language/clbye.rst
@@ -7,10 +7,6 @@ clbye: A cl followed by a bye (used to save file descriptors)
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  cl    -- call the CL as a task
-  clbye -- like cl(), but closes current script file too
-  </pre></div>
   <section id="s_parameters">
   <h3>Parameters</h3>
   <dl id="l_gcur">

--- a/doc/tasks/language/defpac.rst
+++ b/doc/tasks/language/defpac.rst
@@ -7,12 +7,6 @@ defpac: Test if a package is defined
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  defpac  -- test if the named package is defined
-  deftask -- test if the named task is defined
-  defpar  -- test if the named parameter is defined
-  defvar  -- test if the named environment variable is defined
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/defpar.rst
+++ b/doc/tasks/language/defpar.rst
@@ -7,12 +7,6 @@ defpar: Test if a parameter is defined
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  defpac  -- test if the named package is defined
-  deftask -- test if the named task is defined
-  defpar  -- test if the named parameter is defined
-  defvar  -- test if the named environment variable is defined
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/deftask.rst
+++ b/doc/tasks/language/deftask.rst
@@ -7,12 +7,6 @@ deftask: Test if a task is defined
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  defpac  -- test if the named package is defined
-  deftask -- test if the named task is defined
-  defpar  -- test if the named parameter is defined
-  defvar  -- test if the named environment variable is defined
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/defvar.rst
+++ b/doc/tasks/language/defvar.rst
@@ -7,12 +7,6 @@ defvar: Test if an environment variable is defined
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  defpac  -- test if the named package is defined
-  deftask -- test if the named task is defined
-  defpar  -- test if the named parameter is defined
-  defvar  -- test if the named environment variable is defined
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/fprint.rst
+++ b/doc/tasks/language/fprint.rst
@@ -7,11 +7,6 @@ fprint: Print a line into a parameter
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  print  -- print to the standard output
-  fprint -- print to a parameter
-  printf -- formatted print to the standard output
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/fscan.rst
+++ b/doc/tasks/language/fscan.rst
@@ -7,13 +7,6 @@ fscan: Scan a list
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  scan   -- read parameters from standard input
-  fscan  -- read parameters from file, or another parameter
-  scanf  -- formatted read from standard input
-  fscanf -- formatted read from file, or another parameter
-  nscan  -- get number of parameters scanned
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/fscanf.rst
+++ b/doc/tasks/language/fscanf.rst
@@ -7,13 +7,6 @@ fscanf: Formatted read from a file, or another parameter
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  scan   -- read parameters from standard input
-  fscan  -- read parameters from file, or another parameter
-  scanf  -- formatted read from standard input
-  fscanf -- formatted read from file, or another parameter
-  nscan  -- get number of parameters scanned
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/logging.rst
+++ b/doc/tasks/language/logging.rst
@@ -7,9 +7,6 @@ logging: Discussion of CL logging
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  logging -- Using the CL logging features
-  </pre></div>
   <section id="s_description">
   <h3>Description</h3>
   <p>

--- a/doc/tasks/language/print.rst
+++ b/doc/tasks/language/print.rst
@@ -7,11 +7,6 @@ print: Print a line on the standard output
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  print  -- print to the standard output
-  fprint -- print to a parameter
-  printf -- formatted print to the standard output
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/printf.rst
+++ b/doc/tasks/language/printf.rst
@@ -7,11 +7,6 @@ printf: Formatted print to the standard output
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  print  -- print to the standard output
-  fprint -- print to a parameter
-  printf -- formatted print to the standard output
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/redefine.rst
+++ b/doc/tasks/language/redefine.rst
@@ -7,10 +7,6 @@ redefine: Redefine a task
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  task     -- define a new IRAF task
-  redefine -- redefine an IRAF task
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/reset.rst
+++ b/doc/tasks/language/reset.rst
@@ -7,10 +7,6 @@ reset: Reset the value of an environment variable
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-    set -- set the value of an IRAF environment variable
-  reset -- reset (overwrite) the value of an IRAF environment variable
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/scan.rst
+++ b/doc/tasks/language/scan.rst
@@ -7,13 +7,6 @@ scan: Scan the standard input
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  scan   -- read parameters from standard input
-  fscan  -- read parameters from file, or another parameter
-  scanf  -- formatted read from standard input
-  fscanf -- formatted read from file, or another parameter
-  nscan  -- get number of parameters scanned
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/scanf.rst
+++ b/doc/tasks/language/scanf.rst
@@ -7,13 +7,6 @@ scanf: Formatted read from the standard input
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  scan   -- read parameters from standard input
-  fscan  -- read parameters from file, or another parameter
-  scanf  -- formatted read from standard input
-  fscanf -- formatted read from file, or another parameter
-  nscan  -- get number of parameters scanned
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/set.rst
+++ b/doc/tasks/language/set.rst
@@ -7,10 +7,6 @@ set: Set an environment variable
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-    set -- set the value of an IRAF environment variable
-  reset -- reset (overwrite) the value of an IRAF environment variable
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/task.rst
+++ b/doc/tasks/language/task.rst
@@ -7,10 +7,6 @@ task: Define a new task
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  task     -- define a new IRAF task
-  redefine -- redefine an IRAF task
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/whereis.rst
+++ b/doc/tasks/language/whereis.rst
@@ -7,10 +7,6 @@ whereis: locate all occurences of a task in the package list
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  which -- locate a task in the package list
-  whereis -- locate all occurrences of a task in the package list
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/language/which.rst
+++ b/doc/tasks/language/which.rst
@@ -7,10 +7,6 @@ which: locate a task in the package list
 
 .. raw:: html
 
-  <div class="highlight-default-notranslate"><pre>
-  which -- locate a task in the package list
-  whereis -- locate all occurrences of a task in the package list
-  </pre></div>
   <section id="s_usage">
   <h3>Usage</h3>
   <div class="highlight-default-notranslate"><pre>

--- a/doc/tasks/nfextern/newfirm/cgroup.rst
+++ b/doc/tasks/nfextern/newfirm/cgroup.rst
@@ -7,4 +7,8 @@ cgroup: Group exposures
 
 .. raw:: html
 
+  <p>
+  See <b>combine</b>.
+  </p>
+  <!-- Contents:  -->
   

--- a/doc/tasks/nfextern/newfirm/dcombine.rst
+++ b/doc/tasks/nfextern/newfirm/dcombine.rst
@@ -7,4 +7,8 @@ dcombine: Combine dark exposures
 
 .. raw:: html
 
+  <p>
+  See <b>combine</b>.
+  </p>
+  <!-- Contents:  -->
   

--- a/doc/tasks/nfextern/newfirm/fcombine.rst
+++ b/doc/tasks/nfextern/newfirm/fcombine.rst
@@ -7,4 +7,8 @@ fcombine: Combine flat exposures
 
 .. raw:: html
 
+  <p>
+  See <b>combine</b>.
+  </p>
+  <!-- Contents:  -->
   

--- a/doc/tasks/noao/imred/crutil/overview.rst
+++ b/doc/tasks/noao/imred/crutil/overview.rst
@@ -7,6 +7,10 @@ overview: Overview of the package
 
 .. raw:: html
 
+  <p>
+  The cosmic ray package provides tools for identifying and removing cosmic
+  rays in images.  The tasks are:
+  </p>
   <div class="highlight-default-notranslate"><pre>
   cosmicrays - Remove cosmic rays using flux ratio algorithm
    craverage - Detect CRs against average and avoid objects
@@ -17,3 +21,70 @@ overview: Overview of the package
     crmedian - Detect and replace cosmic rays with median filter
     crnebula - Detect and replace cosmic rays in nebular data
   </pre></div>
+  <p>
+  The best way to remove cosmic rays is using multiple exposures of the same
+  field.  When this is done the task <b>crcombine</b> is used to combine the
+  exposures into a final single image with cosmic rays removed.  The images
+  are scaled (if necessary) to a common data level either by multiplicative
+  scaling, an additive background offset, or some combination of both.
+  Cosmic rays are then found as pixels which differ by some statistical
+  amount away for the average or median of the data.
+  </p>
+  <p>
+  A median is the simplest way to remove cosmic rays.  This is an option
+  with <b>crcombine</b>.  But this does not make optimal use of the data.
+  An average of the pixels remaining after some rejection operation is better.
+  If the noise characteristics of the data can be described by a gain and
+  read noise then cosmic rays can be optimally rejected using the
+  <span style="font-family: monospace;">"crreject"</span> algorithm.  This works on two or more images.  There are
+  a number of other rejection algorithms which can be used as described in
+  the task help.
+  </p>
+  <p>
+  The rest of the tasks in the package are used when only a single exposure
+  is available.  These include interactive editing with <b>credit</b>.  The
+  replacement algorithms in this task may also be used non-interactively if
+  you have a list of pixel coordinates as input.  Other tasks automatically
+  identifying pixels which are significantly higher than surrounding pixels.
+  </p>
+  <p>
+  The simplest of these tasks is <b>crmedian</b>.  This replaces
+  cosmic rays with a median value and produces a cosmic ray
+  mask which is a simple type of integer image where good pixels have a value
+  of zero and bad pixels have a non-zero value.  The tasks <b>crgrow</b> and
+  <b>crfix</b> are provided to use this type of cosmic ray mask.  The former
+  will flag additional pixels within some radius of the flagged pixels in the
+  mask.  The latter is the basic tool for replacing the identified pixels in
+  the data by neighboring data.  It uses linear interpolation along lines or
+  columns.  The median task is simple but it often will flag the cores of
+  stars or other small but real features.
+  </p>
+  <p>
+  The task <b>craverage</b> is similar to <b>crmedian</b> in that it compares
+  the pixel values against a smoothed version.  Instead of a median it uses
+  an average with the central pixel excluded.  It is more sophisticated
+  in that it also compares the average against a larger median to see if
+  the region corresponds to an object.  Thus it can detect objects and
+  the task could be used as a simple object detection task in its own right.
+  Because the hardest part of cosmic ray detection from a single image is
+  avoiding truncation of the cores of stars this task does not allow cosmic
+  rays to be detected where it thinks there is an object.  This task is
+  also more versatile in allow separate mask values and works on a list
+  of images.
+  </p>
+  <p>
+  Somewhat more sophisticated algorithms are available in the tasks
+  <b>cosmicrays</b> and <b>crnebula</b>.  These attempt to determine if a
+  deviant pixel is the core of a star or part of a linear nebular feature
+  respectively.
+  </p>
+  <p>
+  The best use of these tasks is to experiment and iterate.  In particular,
+  one may want to iterate a task several times and use both <b>cosmicrays</b>
+  and <b>craverage</b>.
+  </p>
+  <p>
+  Good hunting!
+  </p>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/noao/twodspec/apextract/apbackground.rst
+++ b/doc/tasks/noao/twodspec/apextract/apbackground.rst
@@ -7,6 +7,83 @@ apbackground: Background subtraction algorithms
 
 .. raw:: html
 
+  <p>
+  Data from slit spectra allow the determination and subtraction
+  of the background sky using information from regions near the object
+  of interest.  Background subtraction may also apply to cases of
+  scattered light though other techniques for scattered light removal
+  may be more appropriate.  The APEXTRACT package provides for determining
+  the background level at each wavelength (line or column along the dispersion
+  axis) from a set of regions and extrapolating and subtracting the
+  background at each pixel extracted from the object profile.  The
+  type of background used during extraction is specified by the parameter
+  <i>background</i>.  If the value <span style="font-family: monospace;">"none"</span> is used then no background is
+  subtracted and any background parameters defined for an aperture are
+  ignored.  If the value is <span style="font-family: monospace;">"average"</span>, <span style="font-family: monospace;">"median"</span>, <span style="font-family: monospace;">"minimum"</span> or <span style="font-family: monospace;">"fit"</span> then a
+  background is determined, including a variance estimate when using variance
+  weighted extraction (see <i>apvariance</i>), and the subtracted background
+  spectrum may be output if the <i>extras</i> parameter is set.
+  </p>
+  <p>
+  The basic aperture definition structure used in the APEXTRACT package
+  includes associated background regions and fitting parameters.  The
+  background regions are specified by a list of colon delimited ranges
+  defined relative to the center of the aperture.  There are generally
+  two ranges, one on each side of the object, though one sided or more
+  complex sets may be used to avoid contaminated or missing parts
+  of the slit.  The default ranges are defined by the parameter
+  <i>b_sample</i>.  Often the ranges are better set graphically using a
+  cursor by invoking the <span style="font-family: monospace;">'b'</span> option of the aperture editor.
+  </p>
+  <p>
+  If the background type is <span style="font-family: monospace;">"average"</span>, <span style="font-family: monospace;">"median"</span>, or <span style="font-family: monospace;">"minimum"</span> then pixels
+  occupying these regions are averaged, medianed, or the minimum found to
+  produce a single background level for all object pixels at each wavelength.  
+  Note that the <span style="font-family: monospace;">"average"</span> choice does not exclude any pixels which may
+  yield a background contaminated by cosmic rays.  The <span style="font-family: monospace;">"median"</span> or <span style="font-family: monospace;">"minimum"</span>
+  is recommended instead.
+  </p>
+  <p>
+  If the background type is <span style="font-family: monospace;">"fit"</span> then a function is fit to the pixels in the
+  background regions using the ICFIT options (see <b>icfit</b>).  The
+  parameter <i>b_naverage</i> may be used to compute averages or medians of
+  groups or all of the points within each sample region.  The fit is defined
+  by a function type <i>b_function</i>; one of legendre polynomial, chebyshev
+  polynomial, linear spline, or cubic spline, and function order
+  <i>b_order</i> (number of polynomial terms or spline pieces).  An
+  interactive rejection of grossly deviant points from the fit may also be
+  used.  The fitted function can define a constant, sloped, or higher order
+  background for the object pixels.
+  </p>
+  <p>
+  Note that the background setting function, the <span style="font-family: monospace;">'b'</span> key in <b>apedit</b>,
+  may be used to set the background regions for all the background options
+  but it will always show the result of a fit regardless of the background
+  type.
+  </p>
+  <p>
+  After determining a background by averaging, medianing, minimizing, or
+  fitting, a box car smoothing step may be applied.  The box car size is
+  given by the parameter <i>skybox</i>.  When the number of available
+  background pixels is small, due to a small slit for instance, the noise
+  introduced to the extracted object spectrum may be unsatisfactorily large.
+  By smoothing the background one can reduce the noise when the background
+  consists of a smooth continuum.  The trade-off, however, is that near sharp
+  features the smoothing will smear the features out and give a poorer
+  subtraction of these features.  One could extract both the object and
+  background separately and apply a background smoothing separately using
+  other image processing tools.  However, this is not possible for variance
+  weighted extraction because of the intimate connection between the
+  background levels, the profile determination, and the variance estimates
+  based on both.  Thus, this smoothing feature is included.
+  </p>
+  <p>
+  The background determined by the methods outlined above is actually
+  subtracted as a separate step during extraction.  The background
+  is also used during profile fitting when cleaning or using variance
+  weighted extraction.  See <b>apvariance</b> and <b>approfile</b> for
+  further discussion.
+  </p>
   <section id="s_see_also">
   <h3>See also</h3>
   <p>

--- a/doc/tasks/noao/twodspec/apextract/approfiles.rst
+++ b/doc/tasks/noao/twodspec/apextract/approfiles.rst
@@ -7,6 +7,138 @@ approfiles: Profile determination algorithms
 
 .. raw:: html
 
+  <p>
+  The foundation of variance weighted or optimal extraction, cosmic ray
+  detection and removal, two dimensional flat field normalization, and
+  spectrum fitting and modeling is the accurate determination of the
+  spectrum profile across the dispersion as a function of wavelength.
+  The previous version of the APEXTRACT package accomplished this by
+  averaging a specified number of profiles in the vicinity of each
+  wavelength after correcting for shifts in the center of the profile.
+  This technique was sensitive to perturbations from cosmic rays
+  and the exact choice of averaging parameters.  The current version of
+  the package uses two different algorithm which are much more stable.
+  </p>
+  <p>
+  The basic idea is to normalize each profile along the dispersion to
+  unit flux and then fit a low order function to sets of unsaturated
+  points at nearly the same point in the profile parallel to the
+  dispersion.  The important point here is that points at the same
+  distance from the profile center should have the nearly the same values
+  once the continuum shape and spectral features have been divided out.
+  Any variations are due to slow changes in the shape of the profile with
+  wavelength, differences in the exact point on the profile, pixel
+  binning or sampling, and noise.  Except for the noise, the variations
+  should be slow and a low order function smoothing over many points will
+  minimize the noise and be relatively insensitive to bad pixels such as
+  cosmic rays.  Effects from bad pixels may be further eliminated by
+  chi-squared iteration and clipping.  Since there will be many points
+  per degree of freedom in the fitting function the clipping may even be
+  quite aggressive without significantly affecting the profile
+  estimates.  Effects from saturated pixels are minimized by excluding
+  from the profile determination any profiles containing one or more
+  saturated pixels as defined by the <i>saturation</i> parameter.
+  </p>
+  <p>
+  The normalization is, in fact, the one dimensional spectrum.  Initially
+  this is the simple sum across the aperture which is then updated by the
+  variance weighted sum with deviant pixels possibly removed.  This updated
+  one dimensional spectrum is what is meant by the profile normalization
+  factor in the discussion below.  The two dimensional spectrum model or
+  estimate is the product of the normalization factor and the profile.  This
+  model is used for estimating the pixel intensities and, thence, the
+  variances.
+  </p>
+  <p>
+  There are two important requirements that must be met by the profile fitting
+  algorithm.  First it is essential that the image data not be
+  interpolated.  Any interpolation introduces correlated errors and
+  broadens cosmic rays to an extent that they may be confused with the
+  spectrum profile, particularly when the profile is narrow.  This was
+  one of the problems limiting the shift and average method used
+  previously.  The second requirement is that data fit by the smoothing
+  function vary slowly with wavelength.  This is what precludes, for
+  instance, fitting profile functions across the dispersion since narrow,
+  marginally sampled profiles require a high order function using only a
+  very few points.  One exception to this, which is sometimes useful but
+  of less generality, is methods which assume a model for the profile
+  shape such as a gaussian.  In the methods used here there is no
+  assumption made about the underlying profile other than it vary
+  smoothly with wavelength.
+  </p>
+  <p>
+  These requirements lead to two fitting algorithms which the user
+  selects with the <i>pfit</i> parameter.  The primary method, <span style="font-family: monospace;">"fit1d"</span>,
+  fits low order, one dimensional functions to the lines or columns
+  most nearly parallel to the dispersion.  While this is intended for
+  spectra which are well aligned with the image axes, even fairly large
+  excursions or tilts can be adequately fit in this
+  way.  When the spectra become strongly tilted then single lines or
+  columns may cross the actual profile relatively quickly causing the
+  requirement of a slow variation to be violated.  One thought is to use
+  interpolation to fit points always at the same distance from the
+  profile.  This is ruled out by the problems introduced by
+  image interpolation.  However, there is a clever method which, in
+  effect, fits low order polynomials parallel to the direction defined by
+  tracing the spectrum but which does not interpolate the image data.
+  Instead it weights and couples polynomial coefficients.  This
+  method was developed by Tom Marsh and is described in detail in the
+  paper, <span style="font-family: monospace;">"The Extraction of Highly Distorted Spectra"</span>, PASP 101, 1032,
+  Nov. 1989.  Here we refer to this method as the Marsh or <span style="font-family: monospace;">"fit2d"</span>
+  algorithm and do not attempt to explain it further.
+  </p>
+  <p>
+  The choice of when to use the one dimensional or the two dimensional
+  fitting is left to the user.  The <span style="font-family: monospace;">"fit1d"</span> algorithm is preferable since it
+  is faster, easier to understand, and has proved to be very robust.  The
+  <span style="font-family: monospace;">"fit2d"</span> algorithm usually works just as well but is slower and has been
+  seen to fail on some data.  The user may simply try both to achieve the
+  best results.
+  </p>
+  <p>
+  What follows are some implementation details of the preceding ideas in the
+  APEXTRACT package.  For column/line fitting, the fitting function is a
+  cubic spline.  A base number of spline pieces is set by rounding up the
+  maximum trace excursion; an excursion of 1.2 pixels would use a spline of 2
+  pieces.  To this base number is added the number of coefficients in the
+  trace function in excess of two; i.e. the number of terms in excess of a
+  linear function.  This is done because if the trace wiggles a large amount
+  then a higher order function will be needed to fit a line or column as the
+  profile shifts under it.  Finally the number of pieces is doubled
+  because experience shows that for low tilts it doesn't matter but for
+  large tilts this improves the results dramatically.
+  </p>
+  <p>
+  For the Marsh algorithm there are two parameters to be set, the
+  polynomial order parallel to the dispersion and the spacing between
+  parallel, coupled polynomials.  The algorithm requires that the spacing
+  be less than a pixel to provide sufficient sampling.  The spacing is
+  arbitrarily set at 0.95 pixels.  Because the method always fits
+  polynomials to points at the same position of the profile the order
+  should be 1 except for variations in the profile shape with
+  wavelength.  To allow for this the profile order is set at 10; i.e. a
+  9th order function.  A final parameter in the algorithm is the number
+  of polynomials across the profile but this is obviously  determined
+  from the polynomial spacing and the width of the aperture including an
+  extra pixel on either side.
+  </p>
+  <p>
+  Both fitting algorithms weight the pixels by their variance as computed
+  from the background and background variance if background subtraction
+  is specified, the spectrum estimate from the profile and the spectrum
+  normalization, and the detector noise parameters.  A poisson
+  plus constant gaussian readout noise model is used.  The noise model is
+  described further in <b>apvariance</b>.
+  </p>
+  <p>
+  As mentioned earlier, the profile fitting can be iterated to remove
+  deviant pixels.  This is done by rejecting pixels greater than a
+  specified number of sigmas above or below the expected value based
+  on the profile, the normalization factor, the background, the
+  detector noise parameters, and the overall chi square of the residuals.
+  Rejected points are removed from the profile normalization and
+  from the fits.
+  </p>
   <section id="s_see_also">
   <h3>See also</h3>
   <p>

--- a/doc/tasks/noao/twodspec/apextract/apvariance.rst
+++ b/doc/tasks/noao/twodspec/apextract/apvariance.rst
@@ -7,10 +7,75 @@ apvariance: Extractions, variance weighting, cleaning, and noise model
 
 .. raw:: html
 
+  <p>
+  There are two types of aperture extraction (estimating the background
+  subtracted flux across a fixed width aperture at each image line or
+  column) in the APEXTRACT package.  One is a simple sum of pixel values
+  across an aperture.  It is selected by specifying <span style="font-family: monospace;">"none"</span> for the
+  <i>weights</i> parameter.  The second type weights each pixel in the sum
+  by it's estimated variance based on a spectrum model and detector noise
+  parameters.  This type of extraction is selected by specifying
+  <span style="font-family: monospace;">"variance"</span> for the weighting parameter.  These two extractions are
+  defined by the following equations.
+  </p>
   <div class="highlight-default-notranslate"><pre>
       none:   S = sum { I - B }
   variance:   S = sum { (P**2 / V) (I - B) / P } / sum { P**2 / V }
   </pre></div>
+  <p>
+  S is the one dimensional spectrum flux at a particular wavelength (line
+  or column along the dispersion axis).  The sum is over all pixels at
+  that wavelength within the aperture limits.  If the aperture endpoints
+  occupy only a fraction of a pixel then the pixel value above the
+  background is multiplied by the fraction.  I is the pixel value and B
+  is the estimated background at that pixel (see <b>apbackground</b>), P
+  is estimated normalized profile value for that pixel (see
+  <b>approfile</b>), and V is the estimated variance of the pixel based on
+  the noise model described below.  Note that the quantity (I-B)/P is an
+  independent estimate of the total flux from one pixel since the
+  integral of P is one and it is these estimates that are variance
+  weighted.
+  </p>
+  <p>
+  Variance weighting is often called <span style="font-family: monospace;">"optimal"</span> extraction since it
+  produces the best unbiased signal-to-noise estimate of the flux in the
+  two dimensional profile.  The theory and application of this type of
+  weighting has been described in several papers.  The ones which were
+  closely examined and used as a model for the algorithms in this
+  software are <span style="font-family: monospace;">"An Optimal Extraction Algorithm for CCD Spectroscopy"</span>,
+  PASP 98, 609, 1986, by Keith Horne and <span style="font-family: monospace;">"The Extraction of Highly
+  Distorted Spectra"</span>, PASP 100, 1032, 1989, by Tom Marsh.
+  </p>
+  <p>
+  The noise model for the image data used in the variance weighting,
+  cleaning, and profile fitting consists of a constant gaussian noise and
+  a photon count dependent poisson noise.  The signal is related to the
+  number of photons detected in a pixel by a gain parameter given
+  as the number of photons per data number.  The gaussian noise is given
+  by a <i>readnoise</i> parameter which is a defined as a sigma in
+  photons.  The poisson noise is approximated as gaussian with sigma
+  given by the number of photons.
+  </p>
+  <p>
+  Some additional effects which should be considered in principle, and
+  which are possibly important in practice, are that the variance
+  estimate should be based on the actual number of photons detected before
+  correction for pixel sensitivity; i.e. before flat field correction.
+  Furthermore the uncertainty in the flat field should also be included
+  in the weighting.  However, the profile must be determined free of
+  sensitivity effects including rapid larger scale variations such as
+  fringing.  Thus, ideally one should input the unflat-fielded
+  observation and the flat field data and carry out the extractions with
+  the above points in mind.  However, due to the complexity often
+  involved in basic CCD reductions and special steps required for
+  producing spectroscopic flat fields this level of sophistication is not
+  provided by the current package.  The package does provide, however,
+  for propagation of an approximate uncertainty in the background
+  estimate when using background subtraction.
+  </p>
+  <p>
+  The noise model is described by the following equations.
+  </p>
   <div class="highlight-default-notranslate"><pre>
   (1) V = max (VMIN, (R**2 + I + VB) / G**2)
           max (VMIN, (R**2 + S * P + B + VB) / G**2)
@@ -21,6 +86,88 @@ apvariance: Extractions, variance weighting, cleaning, and noise model
   (3) VMIN = 1 / G**2         if (R = 0)
              R**2 / G**2      if (R &gt; 0)
   </pre></div>
+  <p>
+  V is the desired variance of a pixel to use for variance weighting.  R
+  is the photon read out noise specified by the parameter <i>readnoise</i>
+  and G is the photon per data value gain specified by the parameter
+  <i>gain</i>.  There are two forms to (1).  The first is used in the
+  initial pass of estimating the spectrum flux S and the actual pixel
+  value I (which includes any background) is used for the poisson term.
+  The other form is used in a second pass (and further passes if
+  cleaning) using the estimated data value based on the normalized
+  profile P scaled to the estimated total flux plus the estimated
+  background B; i.e. I estimated = S * P + B.
+  </p>
+  <p>
+  The background variance VB is computed using the poisson noise model
+  based on the estimated background counts.  If no background subtraction
+  is done then both B and VB are set to zero.  If a background is
+  determined the background is either an average or function fit to
+  pixels in defined background regions.  If a fit is used B need not be a
+  constant.   Because the background estimate is based on a finite number of
+  pixels, the poisson variance estimate is divided by the number N (minus
+  one) of pixels used in determining the background.  The number of
+  pixels used includes any box car smoothing.  Thus, the larger the
+  number of background pixels the smaller the background noise
+  contribution to the variance weighting.  This method is only
+  approximate since no correction is made for the number of degrees of
+  freedom and correlations when using the fitting method of background
+  estimation.
+  </p>
+  <p>
+  VMIN is a minimum variance need to avoid generating zero or negative
+  variances from the data.  The definition of VMIN is such that if a zero
+  read out noise is specified (which is certainly possible such as with
+  photon counting detectors) then a minimum of 1 photon is imposed.
+  Otherwise the minimum is set by the read out noise even if the poisson
+  count part is (unphysically) negative.
+  </p>
+  <p>
+  One deviation from the linear photon response mode which is considered
+  is saturation.   A data level specified by the parameter
+  <i>saturation</i> is used to exclude data from the profile fitting.
+  During extraction the saturated pixels are not treated any differently
+  than unsaturated pixels except that dispersion points with saturated
+  pixels are flagged by reversing the sign of the final estimated sigma;
+  the sigma output is enabled with the <i>extras</i> parameter.  Exclusion
+  of saturated pixels from the extraction, as is done with deviant
+  pixels, was tried but this resulted in higher noise in the spectrum.
+  </p>
+  <p>
+  If removal of cosmic rays and other deviant pixels is desired, called
+  cleaning and selected with a <i>clean</i> parameter, they are
+  iteratively rejected based on the estimated variance and excluded from
+  the weighted sum.  Note that a cleaned extraction is always variance
+  weighted regardless of the value of the <i>weights</i> parameter.  This
+  makes sense since the detector noise parameters must be specified and
+  the spectrum profile computed, so all of the computational effort must
+  be done anyway, and the variance weighting is as good or superior to a
+  simple unweighted extraction.
+  </p>
+  <p>
+  The detection and removal of deviant pixels is straightforward.  Based
+  on the noise model described earlier, pixels deviating by more than a
+  specified number of sigma (square root of the variance) above or below
+  the model are removed from the weighted sum.  A new spectrum estimate
+  is made and the rejection is repeated.  The rejections are made one at
+  a time starting with the most deviant and up to half the pixels in the
+  aperture may be rejected.  The total number of rejected pixels in the
+  spectrum is recorded in the logfile and a profile plot of data and
+  model profile is recorded in the plotfile.
+  </p>
+  <p>
+  As a final step when computing a weighted/cleaned spectrum the total
+  fluxes from the weighted spectrum and the simple unweighted spectrum
+  (excluding any deviant and saturated pixels) are computed and a
+  <span style="font-family: monospace;">"bias"</span> factor of the ratio of the two fluxes is multiplied into
+  the weighted spectrum and the sigma estimate.  This makes the total
+  fluxes the same.  The bias factor is recorded in the logfile
+  if one is kept.  Also a check is made for unusual bias factors.
+  If the two fluxes disagree by more than a factor of two a warning
+  is given on the standard output and the logfile with the individual
+  total fluxes as well as the bias factor.  If the bias factor is
+  negative a warning is also given and no bias factor is applied.
+  </p>
   <section id="s_see_also">
   <h3>See also</h3>
   <p>

--- a/doc/tasks/proto/color/package.rst
+++ b/doc/tasks/proto/color/package.rst
@@ -7,11 +7,186 @@ package: Guide to color image display
 
 .. raw:: html
 
+  <p>
+  INTRODUCTION
+  </p>
+  <p>
+  This guide describes techniques for taking three monochrome IRAF images, a
+  <span style="font-family: monospace;">"red"</span> image, a <span style="font-family: monospace;">"green"</span> image, and a <span style="font-family: monospace;">"blue"</span> image and making color
+  composites.  There are many techniques which depend on different hardware
+  and software.  This guide currently discusses three methods for display on
+  an 8-bit color workstation, using Sun 24-bit RGB rasterfiles, creating a
+  special color map and image which samples the RGB color space, and pixel
+  dithering.  The rasterfiles may be displayed or printed using a variety or
+  non-IRAF tools which are readily available and which can be used with 8-bit
+  workstations.  The special color map and pixel dithering methods use only
+  IRAF images and the standard SAOimage/IMTOOL display servers to display on
+  8-bit color workstation.  These techniques are intended to provide a
+  rudimentary color composite capability in absence of better hardware such
+  as IIS/IVAS devices or 24-bit workstations.
+  </p>
+  <p>
+  For further information on the tasks described here see the approriate
+  help pages.
+  </p>
+  <p>
+  SUN 24-BIT RGB RASTERFILES
+  </p>
+  <p>
+  The task <b>rgbsun</b> takes three input IRAF images and produces a 24-bit
+  Sun rasterfile.  Though this file type was developed by Sun Microsystems
+  it is a relatively simple format which may useful on other machines having
+  software designed to use it.  The color image may be display with a variety
+  of tools such as <b>xv</b> (a very powerful and generic viewer for X-window
+  systems), <b>xloadimage</b> (another X-window display tool),
+  <b>screenload</b> (a simple displayer on Sun computers), and <b>snapshot</b>
+  (an Open-Look tool).  Also some color printers can be used with this format
+  such as a Shinko color printer.
+  </p>
+  <p>
+  The recommended display tool is <b>xv</b> which provides a great deal of
+  capability in adjusting the color map and size.  This program compresses the
+  24-bit colors to 8-bits on an 8-bit workstation using color dithering
+  techniques (there is a choice of a slow and fast method).  This program
+  also provides the capability to write the picture out to other formats and
+  one may also use screen capture tools such as <b>xwd</b> or <b>snapshot</b>
+  to extract and possibly print the picture.
+  </p>
+  <p>
+  For hardcopy there is always the option of photographing the workstation
+  screen.  Different sites may also have color printers which accept
+  the rasterfile directly or some other form of capture from the screen.
+  At NOAO there is a Shinko color printer which may be used directly with
+  the rasterfile to make moderate quality color prints and slides.
+  </p>
+  <p>
+  24-BIT to 8-BIT COLOR MAP COMPRESSION
+  </p>
+  <p>
+  The task <b>rgbto8</b> produces an 8-bit color map which samples the full
+  range of RGB color values and an associated image with values indexing the
+  color map.  The compression algorithm is called the Median Cut Algorithm
+  and the image is dithered with this color map using the Floyd-Steinberg
+  algorithm.  The resulting image is a short image with 199 values.  The
+  color map is output in either a format suitable for use with SAOimage or
+  with IMTOOL.  This method is recommended over the pixel dithering method.
+  </p>
+  <p>
+  The RGB values are input as three IRAF images.  The images must each be
+  scaled to an 8 bit range.  This is done by specifying a range of input
+  values to be mapped to the 8 bit range.  In addition the range can be
+  mapped logarithmically to allow a greater dynamic range.
+  </p>
+  <p>
+  The output image is displayed with <b>rgbdisplay</b> and SAOimage, IMTOOL,
+  or XIMTOOL.  Note that this requires V1.07 of SAOimage.  The color map
+  produced by the <b>rgbto8</b> for a particular image must also be loaded
+  into the display server manually.  With IMTOOL use the setup panel and set
+  the file name in the user1 or user2 field and then select the appropriate
+  map.  With SAOimage you select the <span style="font-family: monospace;">"color"</span> main menu function, and then the
+  <span style="font-family: monospace;">"cmap"</span> submenu function, and then the <span style="font-family: monospace;">"read"</span> button.  Note that usually a
+  full pathname is required since the server is usually started from the
+  login directory.  For XIMTOOL the <span style="font-family: monospace;">"XImtool*cmapDir1"</span> resource must be
+  set to the directory containing the color map and XIMTOOL must be
+  restarted to cause the directory to be searched for color map files.
+  </p>
+  <p>
+  The display server must be setup in it's default contrast mapping (with
+  IMTOOL you can use the RESET option, with XIMTOOL the <span style="font-family: monospace;">"normalize"</span> option is
+  used, and with SAOimage you must restart) and the contrast mapping must not
+  be changed.  There are no adjustments that can be made in IMTOOL or XIMTOOL
+  but with SAOimage you can adjust the colors using the <span style="font-family: monospace;">"gamma"</span> selections
+  and the mouse.
+  </p>
+  <p>
+  8-BIT PIXEL DITHERING
+  </p>
+  <p>
+  1. Theory
+  </p>
+  <p>
+  The pixel dithering technique takes the three input IRAF images and makes a
+  special output IRAF image in which each pixel in the input images is expanded
+  into nine pixels in the output image with a specified pattern such as
+  the default of
+  </p>
   <div class="highlight-default-notranslate"><pre>
                   brg
   r + g + b =     gbr
                   rgb
   </pre></div>
+  <p>
+  where r is the red image pixel, g is the green image pixel, and b is the
+  blue image pixel.
+  </p>
+  <p>
+  The pixel intensities are linearly mapped from a specified input range to
+  one of three sets of 85 levels.  The red pixels map to the values 0 to 84,
+  the green pixels to the range 85 to 169, and the blue pixels to the range
+  170 to 254.  The display server then uses a special 8-bit look up table
+  that maps each set of 85 levels in each pure color from off to the maximum
+  intensity.  The displayed image counts on the nearby grouping of pure
+  colors to blend in the detector, such as the eye, to give a color composite
+  effect.
+  </p>
+  <p>
+  This is essentially the same technique used in some kinds of color printing
+  and CRT monitors where each resolution element has three color phosphors
+  and three guns to excite them.  The pixel dithering is also related to
+  black and white half-toning.  As with any of these, if the image is
+  magnified or viewed with enough resolution (by looking very closely at the
+  display) the individual color elements can be distinguished.  However, when
+  viewed normally without magnification the effect is reasonably good.
+  </p>
+  <p>
+  8-BIT PIXEL DITHERING: Usage
+  </p>
+  <p>
+  The composite image is created by the task <b>rgbdither</b> and displayed
+  with the task <b>rgbdisplay</b>.  Unlike the <b>display</b> task there is no
+  automated way to define the display ranges for the three images.  These
+  must be specified explicitly with the image is created.  The ranges may be
+  determined in a variety of ways such as by looking at the histograms,
+  <b>imhist</b>, the statistics of the image, <b>imstat</b>, or possibly the
+  display range produced by <b>display</b>.  Note, however, that often the
+  ranges used to stretch an individual image are not appropriate for color
+  balancing between the three images.
+  </p>
+  <p>
+  Because each input pixel is expanded into nine pixels in the composite
+  image the composite image will have dimensions three times larger than
+  the input image.  The <i>blkavg</i> parameter allows block averaging
+  the input images at the same time that the composite image is created.
+  If a value of 3, the default, is used then the final displayed image
+  will have dimensions nearly the same as the input images.  This is often
+  satisfactory and one should try this first.
+  </p>
+  <p>
+  If one wants to display images which have a large dyanmic range it
+  may be desirable to first take the logarithm of each image.  This may
+  be done with the <i>logmap</i> parameter.  Other types of stretching may
+  be accomplished by modifying the individual images first, say with
+  imfunction.
+  </p>
+  <p>
+  In addition to creating and loading the composite image within IRAF
+  it is also necessary to adjust the image display server.  Either
+  SAOimage or IMTOOL may be used.  SAOimage is prefered because
+  it is possible to make some adjustments in the color mapping while with
+  IMTOOL one must modify the composite image by varying the z1 and z2
+  values for the three images.
+  </p>
+  <p>
+  The display servers must be set so that there is no contrast stretching.
+  This is how the programs start initially but it may be difficult to return
+  to this state if you adjust the contrast with the right mouse button in
+  IMTOOL or the contrast adjustments in the (COLOR) menu of SAOimage.
+  </p>
+  <p>
+  You must first determine where the special color maps are located.
+  Since the display servers are host programs they require host pathnames.
+  You can determine the host pathname from within IRAF using the command
+  </p>
   <div class="highlight-default-notranslate"><pre>
   cl&gt; path colorlib$saorgb.lut
   puppis!/ursa/iraf/extern/color/lib/saorgb.lut
@@ -21,6 +196,11 @@ package: Guide to color image display
   cl&gt; path colorlib$imtoolrgb.lut
   puppis!/ursa/iraf/extern/color/lib/imtoolrgb.lut
   </pre></div>
+  <p>
+  You can either remember these names (without the node prefix) or
+  more simply copy the one you need to your IRAF home directory
+  (or any place else you like) with the command
+  </p>
   <div class="highlight-default-notranslate"><pre>
   cl&gt; copy colorlib$saorgb.lut home$
   
@@ -28,3 +208,39 @@ package: Guide to color image display
   
   cl&gt; copy colorlib$imtoolrgb.lut home$
   </pre></div>
+  <p>
+  With SAOimage load the special look up table by entering the (COLOR) menu,
+  then the (CMAP) menu, and then pushing the (READ) button.  When you are
+  prompted for the map enter the pathname for the file saorgb.lut.  For
+  IMTOOL you need to call up the setup menu and set the pathname for the file
+  imtoolrgb.lut in either of the user look up tables and then select the
+  appropriate map.
+  </p>
+  <p>
+  For IMTOOL that is all you can do.  Beware, don't adjust the contrast (the
+  right mouse button) since this destroys the mapping between the composite
+  image values and the look up table.
+  </p>
+  <p>
+  In SAOimage there are a couple of things you can do to make adjustments to
+  the display.  Bring up the color editor by clicking on the color bar.  Even
+  if you don't adjust the look up table this can be instructive.  If you
+  select (GAMMA) in the (COLOR) menu you can then move the mouse with a
+  button down and vary the linearity of the color maps.  This can be seen in
+  the color editor.  You can also adjust the individual colors by clicking
+  the left (red), middle (green), or right (blue) buttons to either move the
+  shown points or add and move points in the middle.  Note that the abrupt
+  discontinuity between the colors can cause sudden jumps in the color map if
+  one point is moved past the other but you can recover by bring the point
+  slowly back.  If the map gets too messed up you can always reload the color
+  map.
+  </p>
+  <p>
+  One might expect that making a hardcopy of the display would produce a
+  comparable quality image.  This may be the case by photographing the CRT
+  screen.  However, experiments with capturing the displayed image to a
+  rasterfile and printing it on a SHINKO color printer does not produce
+  useful hardcopy.
+  </p>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/st4gem/analysis/fitting/index.rst
+++ b/doc/tasks/st4gem/analysis/fitting/index.rst
@@ -6,3 +6,62 @@ fitting: Curve fitting tools.
    gfit1d
    errorpars
    samplepars
+.. raw:: html
+
+  <p>
+  This package contains tasks that perform function fitting operations on
+  images, STSDAS table columns, or lists.  Both linear and non-linear
+  functions are supported.
+  </p>
+  <p>
+  When fitting 1-dimensional functions with input data from 2- (or
+  more) dimensional images, the data are projected over a 1-dimensional vector
+  before fitting the function. 
+  </p>
+  <p>
+  The fitting tasks write their results to STSDAS tables.  A common table
+  format is used by all tasks in the package, with the same column headers
+  and formats. 
+  </p>
+  <p>
+  The interative linear function fitting task is 'gfit1d' which fits
+  Chebyshev or Legendre polynomials, linear or cubic splines, using
+  Cholesky factorization to solve the standard least-squares normal
+  equations. 
+  </p>
+  <p>
+  Non-linear function fitting is split between several tasks.
+  The first, 'nfit1d', interatively fits each of six different
+  functional forms:
+  </p>
+  <div class="highlight-default-notranslate"><pre>
+  
+  * power law
+  * Planck function
+  * sum of two Planck functions
+  * sum of a power law and a Planck function
+  * galaxy brightness profile (bulge + disk)
+  * user-defined function (implemented by a built-in FORTRAN interpreter)
+  
+  </pre></div>
+  <p>
+  The second task, 'ngaussfit', is meant to interatively fit multiple
+  Gaussians to 1-dimensional data.  The third task, 'n2gaussfit', is a
+  simple non-interactive tool for fitting a 2-dimensional Gaussian to image data. 
+  Task 'i2gaussfit' is a script useful to run 'n2gaussfit' in noisy
+  conditions. 
+  </p>
+  <p>
+  The non-linear fitting can be performed by any of two algorithms, either
+  one of
+  which can be  used to minimize chi-squared: downhill simplex (amoeba) or
+  Levenberg-Marquardt.
+  </p>
+  <p>
+  There is one task to do the inverse operation, that is, to read the table
+  with fitting results and build images, STSDAS tables or lists.  Another
+  task is available to list or print the fitting table contents in a
+  human-readable format.
+  </p>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/st4gem/analysis/fourier/index.rst
+++ b/doc/tasks/st4gem/analysis/fourier/index.rst
@@ -7,3 +7,89 @@ fourier: Fourier analysis.
    forward
    inverse
    taperedge
+.. raw:: html
+
+  <p>
+  This package contains tasks for taking the forward or
+  inverse Fourier transforms---or for using the Fourier
+  transform to compute a power spectrum or perform a cross
+  correlation or convolution.
+  These tasks currently operate only on images,
+  not on tables or lists.
+  Data are assumed to be equally spaced.
+  </p>
+  <p>
+  Rather than using complex data type for input and output images,
+  tasks in the 'fourier' package adopt the convention that
+  the real and imaginary parts are kept in separate images.
+  In many cases there will only be a real part,
+  and there may only be an imaginary part.
+  The user sets the flags 'inreal' &amp; 'inimag' and 'outreal' &amp; 'outimag'
+  to specify which parts are to be read as input and created as output.
+  When both real and imaginary parts are to be read or written,
+  the characters <span style="font-family: monospace;">"r"</span> and <span style="font-family: monospace;">"i"</span> will be appended to the
+  root portion of the name specified by the user
+  to obtain the actual names of the real and imaginary parts respectively.
+  When only the real part or only the imaginary part
+  is to be read or written,
+  the name specified by the user is taken without modification.
+  </p>
+  <p>
+  The Fourier transform is done in single-precision real
+  arithmetic.  The output image is created as a <span style="font-family: monospace;">"new copy"</span>
+  of the input, but the output data type is set to real
+  regardless of the input data type.  This was done because
+  of integer overflow problems with images of type integer or short.
+  </p>
+  <p>
+  A frequently asked question about tasks in the 'fourier' package is,
+  <span style="font-family: monospace;">"Which pixel receives the DC signal when taking a forward transform
+  or power spectrum?  That is,
+  which pixel is zero frequency?"</span>  Zero frequency is at the reference pixel,
+  which is given by the value of CRPIX1 (or CRPIX1 &amp; CRPIX2 for a 2-D image).
+  This will be pixel 1 (or [1,1] for 2-D)
+  if the 'center' parameter was set to no.
+  If center=yes,
+  the reference pixel will be at [N/2] + 1,
+  where N is the length of an image axis.
+  The brackets indicate truncation to an integer.
+  </p>
+  <p>
+  The coordinate parameters of the input image are used to compute
+  appropriate coordinate parameters for the output image.
+  This makes it straightforward to associate a <span style="font-family: monospace;">"world coordinate"</span>
+  value with any pixel in the output image.
+  For an image produced by the 'forward' or 'powerspec' task,
+  the world coordinate at a pixel is the frequency in physical units,
+  such as cycles per second.
+  As an example,
+  consider an image N pixels long with pixel spacing of D seconds per pixel.
+  The pixel spacing in the Fourier domain is 1/(N*D) Hz per pixel.
+  Suppose the input image contains a periodic signal with period P pixels,
+  which is P*D seconds.
+  The periodic signal results in a peak in the Fourier domain
+  at N/P pixels from the reference pixel.
+  The world coordinate (frequency in cycles/sec, in this example) at a pixel
+  is the offset from the reference pixel multiplied by the pixel spacing,
+  or (N/P) * 1/(N*D) = 1/(P*D) Hz,
+  as you would expect for a period of P*D seconds.
+  </p>
+  <p>
+  For a two-dimensional image the pixel spacing changes independently in
+  each dimension.
+  If the length and pixel spacing are N1 &amp; D1 for the first image axis
+  and N2 &amp; D2 for the second image axis,
+  then the pixel spacing in the Fourier domain is 1/(N1*D1) for the first
+  axis and 1/(N2*D2) for the second axis.
+  In general, therefore, the coordinate axes will not be orthogonal
+  in the Fourier domain.
+  The output CD matrix is obtained by multiplying the input CD matrix
+  on the right by the matrix
+  </p>
+  <div class="highlight-default-notranslate"><pre>
+  | 1/(N1*D1**2)       0       |
+  |                            |
+  |      0        1/(N2*D2**2) |
+  </pre></div>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/st4gem/analysis/isophote/index.rst
+++ b/doc/tasks/st4gem/analysis/isophote/index.rst
@@ -3,3 +3,31 @@ isophote: Elliptical isophote image analysis.
 
 .. toctree:: :maxdepth: 1
 
+.. raw:: html
+
+  <p>
+  This package contains tasks which perform elliptical isophote analysis.
+  The main task is 'ellipse', which fits a set of elliptical isophotes over 
+  an image. The algorithm is closely based on the description given by 
+  Jedrzejewski (Mon.Not.R.Astr.Soc., 226, 747, 1987). The output of 
+  isophote fitting is a STSDAS table.
+  </p>
+  <p>
+  The table containing isophote information is used as input by the remaining
+  tasks in this package. Task 'bmodel' reads the table and builds an artificial 
+  image with a photometric model of the original image. 
+  </p>
+  <p>
+  Task 'isoplot' can be used to quickly examine, in graphic form, the run of 
+  any isophote parameter against ellipse semi-major axis. Task 'isopall' 
+  builds a graphic mosaic simultaneously showing the run of nine isophote 
+  parameters against ellipse semi-major axis. Task 'isomap' draws a contour 
+  map of the original image, and superposes on it the ellipses corresponding 
+  to the contoured levels. In an analogous way, task 'isoimap' superposes 
+  ellipses on the gray-scale image display. Task 'isoexam' can be used to 
+  visually inspect the results of a fit, reading ellipses directly from the 
+  table, superposing them either on the image display or the contour graphics,
+  and enabling user interaction through the image/graphics cursor.
+  </p>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/st4gem/graphics/stplot/index.rst
+++ b/doc/tasks/st4gem/graphics/stplot/index.rst
@@ -5,3 +5,123 @@ stplot: General plotting utilities.
 
    igi
    psikern
+.. raw:: html
+
+  <p>
+  The 'stplot' package includes general purpose plotting tasks
+  tailored toward STSDAS data formats; that is, tables and group format
+  image files. These tasks include:
+  </p>
+  <dl id="l_sgraph">
+  <dt><b>sgraph</b></dt>
+  <!-- Sec=None Level=0 Label='sgraph' Line='sgraph' -->
+  <dd>The 'sgraph' task 
+  includes all of the functions of the IRAF 'plot.graph' task, but adds
+  the ability to plot from STSDAS tables (images and text files were supported
+  by 'graph'). In 'sgraph', you can plot a single column against a row, or
+  a column against another column.
+  </dd>
+  </dl>
+  <dl id="l_depind">
+  <dt><b>depind</b></dt>
+  <!-- Sec=None Level=0 Label='depind' Line='depind' -->
+  <dd>The 'depind' task prints pairs of dependent and independent pixel
+  values from two one-dimensional images to STDOUT.  This may be piped to
+  'sgraph' or 'plot.graph' to plot one image line (spectrum) against another.
+  </dd>
+  </dl>
+  <dl id="l_skymap">
+  <dt><b>skymap</b></dt>
+  <!-- Sec=None Level=0 Label='skymap' Line='skymap' -->
+  <dd>The 'skymap' task interprets an STSDAS table as a catalog of
+  coordinates and brightnesses to produce a star chart.  That is, it
+  plots symbols whose size depends on brightness and whose position
+  on the plot is a projection of the celestial coordinates.  There is an
+  interactive interface that allows a user to roam among different
+  parts of the catalog, change the chart scale, and perform other actions.
+  </dd>
+  </dl>
+  <dl id="l_Group">
+  <dt><b>Group Format</b></dt>
+  <!-- Sec=None Level=0 Label='Group' Line='Group Format' -->
+  <dd>Three tasks support group format STSDAS images and plot more
+  than one group member on a single graph.
+  <dl>
+  <dt><b>grlist</b></dt>
+  <!-- Sec=None Level=1 Label='grlist' Line='grlist' -->
+  <dd>A generic task to permit converting a range of groups to a list of image names.  The output list may be used by any task that accepts alist of images as input.
+  </dd>
+  </dl>
+  <dl>
+  <dt><b>grplot</b></dt>
+  <!-- Sec=None Level=1 Label='grplot' Line='grplot' -->
+  <dd>Overplots
+  selected members on a single plot
+  </dd>
+  </dl>
+  <dl>
+  <dt><b>grspec</b></dt>
+  <!-- Sec=None Level=1 Label='grspec' Line='grspec' -->
+  <dd>Uses the
+  'noao.onedspec.specplot' task to allow interaction with a plot of several
+  group members.
+  </dd>
+  </dl>
+  </dd>
+  </dl>
+  <dl id="l_fieldplot">
+  <dt><b>fieldplot</b></dt>
+  <!-- Sec=None Level=0 Label='fieldplot' Line='fieldplot' -->
+  <dd>The 'fieldplot' task is a general purpose task to draw arrows
+  representing a vector field, that is, directions and magnitudes.  Data
+  are read from STDIN to represent the coordinates of a point and the
+  field vector.  The vector may be either a pair of projected magnitudes
+  or the absolute magnitude and direction.  The magnitude may be scaled
+  arbitrarily.
+  </dd>
+  </dl>
+  <dl id="l_igi">
+  <dt><b>igi</b></dt>
+  <!-- Sec=None Level=0 Label='igi' Line='igi' -->
+  <dd>The 'igi' task is an interactive interpreter for producing
+  arbitrary plots.  The syntax of the commands is based on Mongo, but 'igi'
+  operates within IRAF and is device independent. (A complete reference
+  manual for 'igi' is available on request from the STSDAS group.)
+  </dd>
+  </dl>
+  <dl id="l_newcont">
+  <dt><b>newcont</b></dt>
+  <!-- Sec=None Level=0 Label='newcont' Line='newcont' -->
+  <dd>The 'newcont' task is an improved version of 'plot.contour'.  The
+  algorithm used produces smoother contours that will not cross.  
+  It also provides more options for determining contour level and specifying
+  contour line types.
+  </dd>
+  </dl>
+  <dl id="l_rdsiaf">
+  <dt><b>rdsiaf</b></dt>
+  <!-- Sec=None Level=0 Label='rdsiaf' Line='rdsiaf' -->
+  <dd>The 'rdsiaf' task reads in the aperture descriptions from the Project
+  Data Base (PDB) Science Instrument Aperture File (SIAF) and writes
+  them into an SDAS table. This table is used by siaper, which plots
+  the telescope apertures.
+  </dd>
+  </dl>
+  <dl id="l_siaper">
+  <dt><b>siaper</b></dt>
+  <!-- Sec=None Level=0 Label='siaper' Line='siaper' -->
+  <dd>The 'siaper' task uses any graphics device to draw the science 
+  instrument apertures of the HST.
+  It requires an input image containing WCS information. The drawn aperture
+  can then be laid over an image.
+  </dd>
+  </dl>
+  <dl id="l_psikern">
+  <dt><b>psikern</b></dt>
+  <!-- Sec=None Level=0 Label='psikern' Line='psikern' -->
+  <dd>The 'psikern' task is a GIO kernel that translates from IRAF's graphics
+  to PostScript.
+  </dd>
+  </dl>
+  <!-- Contents:  -->
+  

--- a/doc/tasks/st4gem/toolbox/tools/index.rst
+++ b/doc/tasks/st4gem/toolbox/tools/index.rst
@@ -4,3 +4,35 @@ tools: Generic data handling and utility tools.
 .. toctree:: :maxdepth: 1
 
    fparse
+.. raw:: html
+
+  <p>
+  This package contains general utilities for a 
+  variety of applications.
+  </p>
+  <p>
+  Tasks are available in this package 
+  to precess coordinates, convert
+  between time formats, create unique file names,
+  artificially change the redshift of spectra,
+  and make the apropos database file.
+  </p>
+  <p>
+  Utilities for editing image headers are now
+  in the ST4GEM 'toolbox.headers' package.
+  </p>
+  <p>
+  Utilities for working with tables are in
+  the 'toolbox.ttools' package.
+  </p>
+  <p>
+  Tasks that support the process of calibrating
+  HST images are in the 'hst_calib.ctools' package.
+  </p>
+  <p>
+  For an overview of subpackages in the ST4GEM
+  'toolbox' package (including this subpackage),
+  type <span style="font-family: monospace;">"help toolbox opt=sys"</span>.
+  </p>
+  <!-- Contents:  -->
+  

--- a/tools/irafdocs.py
+++ b/tools/irafdocs.py
@@ -100,20 +100,27 @@ def get_help(task, device="text", option="help"):
     if len(lines) < 10:
         return None
 
-    prolog = True
+    part = "header"
     olines = []
     h3 = re.compile(r"<h2>(.*?)</h2>")
     sec = re.compile(r'<section id="s_(.*?)">')
     in_code = False
     codelines = []
     for line in lines:
+        if line == "<p>" and part == "header":
+            olines.clear()
+            part = "body"
         if h3.findall(line):
             hdr = h3.sub(r"\1", line)
             line = "<h3>" + hdr.capitalize() + "</h3>"
         if sec.findall(line):
             section = sec.sub(r"\1", line)
-            if section != "name":
-                prolog = False
+            if section == "name":
+                olines.clear()
+                part = "name"
+            if section != "name" and part != "body":
+                olines.clear()
+                part = "body"
         if "<pre>" in line:
             line = line.replace(
                 "<pre>", '<div class="highlight-default-notranslate"><pre>'
@@ -126,7 +133,7 @@ def get_help(task, device="text", option="help"):
             olines += unindent(codelines)
             olines.append(line)
             in_code = False
-        elif not prolog and not in_code:
+        elif part == "body" and not in_code:
             olines.append(line)
         elif in_code:
             codelines.append(tabwithspace(line.replace("<br>", "")).rstrip())


### PR DESCRIPTION
Some help files don't have the usual structure with sections etc, which are currently not properly rendered, as the tool explicitly searches for a non-"NAME" section.

This PR allows more flexibility here and removes only the HTML header, and the NAME section (if there).