### PR TITLE
Prepare 2.18

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ html_theme_options = {
     'collapse_navigation': True,
 }
 html_static_path = ['_static']
+html_show_sourcelink = False
 
 html_css_files = [
     'brand.css',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,7 +3,7 @@ import sys
 import json
 
 project = 'IRAF'
-release = '2.17.1'
+release = '2.18'
 version = release
 copyright = '1986 Association of Universities for Research in Astronomy Inc.'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,16 +9,10 @@ copyright = '1986 Association of Universities for Research in Astronomy Inc.'
 
 master_doc = 'index'
 extensions = [
-    'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel',
-    'sphinx.ext.extlinks',
     'sphinx_rtd_theme',
     'sphinx_reredirects',
 ]
-
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-}
 
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {


### PR DESCRIPTION
Prepare IRAF release 2.18. Main change is the version number in `doc/conf.py`; the documentation itself is updated automatically.